### PR TITLE
Update Inet calculation

### DIFF
--- a/pthelma/swb.py
+++ b/pthelma/swb.py
@@ -58,7 +58,9 @@ class SoilWaterBalance(object):
             return 1
         return 0
 
-    def __Dr_i_1_calc__(self, Dr_i, Inet_i):
+    def __Dr_i_1_calc__(self, Dr_i, Inet_i, Inet_in):
+        if Inet_in in ["NO"]:
+            Inet_i = 0.0
         if Dr_i - Inet_i > self.taw_mm:
             return self.taw_mm
         return Dr_i - Inet_i
@@ -106,7 +108,11 @@ class SoilWaterBalance(object):
 
     def water_balance(self, theta_init, irr_event_days,
                       start_date, end_date, FC_IRT=1,
-                      Dr_historical=None):
+                      Dr_historical=None, Inet_in="YES"):
+        # add_Inet for irma/aira usage
+        # Inet_calc "YES" or "NO"
+        if Inet_in not in ['YES', 'NO']:
+            raise ValueError("Inet_in must be either 'YES' or 'NO'")
         if len(self.wbm_report) >= 1:
             self.depletion_report = []
         # i = 0
@@ -129,7 +135,7 @@ class SoilWaterBalance(object):
                                               step, Dr_i, FC_IRT)
             theta = self.__theta_calc__(theta_init, Dr_i,
                                         Inet_i, irr_event_days)
-            Dr_i_1 = self.__Dr_i_1_calc__(Dr_i, Inet_i)
+            Dr_i_1 = self.__Dr_i_1_calc__(Dr_i, Inet_i, Inet_in)
             theta_i_1 = theta
             theta_p = theta / (self.rd * self.rd_factor)
             self.wbm_report.append({'date': step,

--- a/tests/test_swb.py
+++ b/tests/test_swb.py
@@ -236,3 +236,15 @@ class SoilWaterBalanceDailyTestCase(TestCase):
         self.assertEqual(values3['irrigate'], 1.0)
         self.assertAlmostEqual(values3['Dr_i'], 51.83859483)
         self.assertAlmostEqual(values3['theta'], 91.66140517)
+
+    def test_swb_daily_Inet_in_wrong_input(self):
+        start_date = datetime(2008, 8, 1)
+        end_date = datetime(2008, 8, 30)
+        theta_init = 131.93750
+        irr_event_days = [datetime(2008, 8, 8, 0, 0),
+                          datetime(2008, 8, 15, 0, 0)]
+
+        with self.assertRaises(ValueError):
+            self.swb.water_balance(theta_init, irr_event_days,
+                                   start_date, end_date,
+                                   FC_IRT=1, Inet_in="Something Else")


### PR DESCRIPTION
This pull request adds the ability to user to select if `Inet` will be added to calculations or not. 

The new parameter added to  method `SoilWaterBalance.water_balance` is called `Inet_in` and can be set either `YES` or `NO` (case sensitive). In any other case a `ValueError` is raised. 

Unit test provides test for the case where a user doesn't provides correct `Inet_in` parameter.  There are no case studies in order to make more complex `unitests` that test the results equality in case of `Inet="NO"` 