### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ nosetests.xml
 
 man/loggertodb.1
 doc/_build
+
+# Mac Related
+.DS_Store


### PR DESCRIPTION
From wiki: https://en.wikipedia.org/wiki/.DS_Store

```
In the Apple macOS operating system,
 .DS_Store is a file that stores custom attributes of its containing folder
```


