### PR TITLE
Use pandas instead of pthelma.timeseries for enhydris-api (fixes #32)

### DIFF
--- a/doc/dev/enhydris_api.rst
+++ b/doc/dev/enhydris_api.rst
@@ -61,17 +61,16 @@ Enhydris API.
    Deletes the specified model. See :func:`get_model` for the
    parameters.
 
-.. function:: read_tsdata(base_url, session_cookies, ts)
+.. function:: read_tsdata(base_url, session_cookies)
 
-   Retrieves the time series data into *ts*, which must be a
-   :class:`~timeseries.Timeseries` object.
+   Retrieves the time series data into a pandas dataframe indexed by date that
+   it returns.
 
-.. function:: post_tsdata(base_url, session_cookies, timeseries)
+.. function:: post_tsdata(base_url, session_cookies, timeseries_id, ts)
 
    Posts a time series to Enhydris "api/tsdata", appending the records
    to any already existing. *session_cookies* is the value returned
-   from :func:`.login`; *timeseries* is a
-   :class:`~timeseries.Timeseries` object that has :attr:`id` defined.
+   from :func:`.login`; *ts* is a pandas dataframe indexed by date.
 
 .. function:: get_ts_end_date(base_url, session_cookies, ts_id)
 

--- a/pthelma/enhydris_api.py
+++ b/pthelma/enhydris_api.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from six import StringIO
 
 import iso8601
+import pandas as pd
 import requests
 
 
@@ -70,17 +71,17 @@ def delete_model(base_url, session_cookies, model, id):
         raise requests.exceptions.HTTPError()
 
 
-def read_tsdata(base_url, session_cookies, ts):
-    r = requests.get(base_url + 'api/tsdata/{0}/'.format(ts.id),
+def read_tsdata(base_url, session_cookies, ts_id):
+    r = requests.get(base_url + 'api/tsdata/{0}/'.format(ts_id),
                      cookies=session_cookies)
     r.raise_for_status()
-    ts.read(StringIO(r.text))
+    return pd.read_csv(StringIO(r.text), header=None, parse_dates=True, index_col=0)
 
 
-def post_tsdata(base_url, session_cookies, timeseries):
+def post_tsdata(base_url, session_cookies, timeseries_id, ts):
     f = StringIO()
-    timeseries.write(f)
-    url = urljoin(base_url, 'api/tsdata/{}/'.format(timeseries.id))
+    ts.to_csv(f, header=False)
+    url = urljoin(base_url, 'api/tsdata/{}/'.format(timeseries_id))
     r = requests.post(
         url,
         data={'timeseries_records': f.getvalue()},

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ installation_requirements = ["pytz",
                              "six>=1.9,<2",
                              "iso8601",
                              "affine",
+                             "pandas>=0.23",
                              ]
 if sys.platform != 'win32':
     installation_requirements.extend(["numpy>=1.5,<2",

--- a/tests/test_enhydris_api.py
+++ b/tests/test_enhydris_api.py
@@ -124,6 +124,7 @@ class PostTsDataTestCase(TestCase):
             'variable': v['variable_id'],
             'unit_of_measurement': v['unit_of_measurement_id'],
             'time_zone': v['time_zone_id'],
+            'precision': 0,
         }
         ts_id = enhydris_api.post_model(v['base_url'], cookies, 'Timeseries',
                                         j)


### PR DESCRIPTION
This is preparation work for taking enhydris-api out of pthelma and making it an independent package and repository. It's not intended to be merged into `master`, but into `future`, which is a branch for hosting such work.

This is backwards-incompatible and causes meteologger/loggertodb to not work, but this will be fixed in #33.