### PR TITLE
haggregate: Improve missing_flag

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -37,6 +37,7 @@ jobs:
 
     - name: Install Dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install -y gdal-bin libgdal-dev postgresql-14-postgis-3
         source ~/.venv/bin/activate
         # numpy<2 is needed for gdal to contain support for gdal array

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+
+DEV
+===
+
+* haggregate: The ``missing_flag`` parameter to ``aggregate()`` can now
+  include the substring "{}", which will be replaced with the number of
+  missing values.
+
 2.0.0 (2024-12-04)
 ==================
 

--- a/docs/haggregate/api.rst
+++ b/docs/haggregate/api.rst
@@ -34,7 +34,14 @@ haggregate API
    than *min_count* source records corresponding, the resulting
    destination record is null; otherwise, the destination record is
    derived even though some records are missing.  In that case, the flag
-   specified by *missing_flag* is raised in the destination record.
+   specified by *missing_flag* is raised in the destination record. If
+   missing flag contains the string ``{}``, it is replaced with the
+   number of missing records. The recommended setting for *missing_flag*
+   is ``MISSING{}``, which, for example, will result in ``MISSING3``
+   when three records are missing. The default for *missing_flag* is
+   ``MISS`` for backwards compatibility (it was ``MISS`` for some years,
+   however this was undocumented), but this is deprecated; use
+   ``MISSING{}``.
 
    If an error occurs, such as *ts* not having a strictly regular step,
    :exc:`AggregateError` (or a subclass) is raised.

--- a/docs/haggregate/usage.rst
+++ b/docs/haggregate/usage.rst
@@ -55,7 +55,7 @@ explanatory comments that follow it:
     base_dir = /var/cache/timeseries/
     target_step = 1h
     min_count = 2
-    missing_flag = DATEINSERT
+    missing_flag = MISSING{}
 
     [temperature]
     source_file = temperature-10min.hts
@@ -133,7 +133,8 @@ General parameters
    to a destination record, the resulting destination record is null;
    otherwise, the destination record is derived even though some records
    are missing. In that case, the flag specified by
-   :option:`missing_flag` is raised in the destination record.
+   :option:`missing_flag` is raised in the destination record. See
+   :meth:`~haggregate.aggregate` for details on :option:`missing_flag`.
 
 Time series sections
 --------------------

--- a/src/haggregate/haggregate.py
+++ b/src/haggregate/haggregate.py
@@ -75,8 +75,8 @@ class Aggregation:
     def get_result_flags(self):
         max_count = int(pd.Timedelta(self.result.time_step) / self.source.freq)
         values_count = self.resampler.count()
-        self.result.data["flags"] = (values_count < max_count).apply(
-            lambda x: self.missing_flag if x else ""
+        self.result.data["flags"] = (max_count - values_count).apply(
+            lambda x: self.missing_flag.format(x) if x else ""
         )
 
 

--- a/tests/haggregate/test_haggregate.py
+++ b/tests/haggregate/test_haggregate.py
@@ -75,7 +75,6 @@ class HourlySumTestCase(TestCase):
 
     def test_value_1(self):
         self.assertAlmostEqual(self.result.data.loc["2008-02-07 10:00"].value, 31.25)
-        self.assertEqual(self.result.data["flags"].loc["2008-02-07 10:00"], "MISS")
 
     def test_value_2(self):
         self.assertAlmostEqual(self.result.data.loc["2008-02-07 11:00"].value, 65.47)
@@ -85,6 +84,25 @@ class HourlySumTestCase(TestCase):
 
     def test_value_4(self):
         self.assertAlmostEqual(self.result.data.loc["2008-02-07 13:00"].value, 72.77)
+
+
+class MissingFlag(TestCase):
+    def _aggregate(self, missing_flag):
+        self.ts = HTimeseries(
+            StringIO(tenmin_test_timeseries), default_tzinfo=ZoneInfo("Etc/GMT-2")
+        )
+        self.ts.data = self.ts.data.iloc[1:]
+        self.result = aggregate(
+            self.ts, "1h", "sum", min_count=2, missing_flag=missing_flag
+        )
+
+    def test_flag_without_num_missing(self):
+        self._aggregate(missing_flag="MISS")
+        self.assertEqual(self.result.data["flags"].loc["2008-02-07 10:00"], "MISS")
+
+    def test_flag_with_num_missing(self):
+        self._aggregate(missing_flag="MISSING{}")
+        self.assertEqual(self.result.data["flags"].loc["2008-02-07 10:00"], "MISSING4")
 
 
 class TimestampIrregularityTestCase(TestCase):


### PR DESCRIPTION
missing_flag can now include the substring "{}", which will be replaced with the number of missing values.